### PR TITLE
Fixed scrolling bug for navbar

### DIFF
--- a/src/components/navbar-components/css/Navbar.css
+++ b/src/components/navbar-components/css/Navbar.css
@@ -1,5 +1,5 @@
 .navbar {
-  position: fixed;
+  /* position: fixed; */
   top: 0px;
   padding: 1em;
 


### PR DESCRIPTION
Removed: 'position: fixed'.

Was causing a bug where every-time you scroll down the page, the navigation bar background won't fully change colour.