### PR TITLE
Fixed responsiveness

### DIFF
--- a/src/components/login-components/Login.js
+++ b/src/components/login-components/Login.js
@@ -117,18 +117,18 @@ const axios = require("axios");
 
 const useStyles = makeStyles((theme) => ({
   paper: {
-    marginTop: theme.spacing(8),
+    // marginTop: theme.spacing(8),
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
   },
   avatar: {
-    margin: theme.spacing(1),
+    marginTop: theme.spacing(13),
     backgroundColor: theme.palette.secondary.main,
   },
   form: {
     width: "100%", // Fix IE 11 issue.
-    marginTop: theme.spacing(1),
+    marginTop: theme.spacing(0),
   },
   submit: {
     margin: theme.spacing(3, 0, 2),


### PR DESCRIPTION
Signin title and icon was previously aligned on the same row as the navbar when resizing the browser and on mobile devices. 