### PR TITLE
repositioned homepage banner

### DIFF
--- a/src/components/home-components/css/Banner.css
+++ b/src/components/home-components/css/Banner.css
@@ -1,6 +1,6 @@
 .banner {
     /* background-color: rgba(128, 128, 128, 0.482); */
-    padding-top: 25%;
+    padding-top: 12rem;
     padding-bottom: 4em;
     /* color: white; */
 }


### PR DESCRIPTION
Needed to scroll down to the next page in order to see the banner on ultrawide monitors.
This has been resolved.